### PR TITLE
Fix storybook webpack import

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,12 @@
 const path = require('path');
 const fs = require('fs');
-const defaultStorybookConfig = require('@storybook/core/dist/server/config/defaults/webpack.config.js');
+const storybookWebpack = require('@storybook/core/dist/server/config/defaults/webpack.config.js');
 const webpack = require('webpack');
 
-module.exports = function happoPluginStorybook({ configDir = '.storybook', ignoredStories = [] } = {}) {
+module.exports = function happoPluginStorybook({
+  configDir = '.storybook',
+  ignoredStories = [],
+} = {}) {
   return {
     customizeWebpackConfig: config => {
       config.plugins.push(
@@ -15,11 +18,7 @@ module.exports = function happoPluginStorybook({ configDir = '.storybook', ignor
           HAPPO_STORYBOOK_IGNORED_STORIES: JSON.stringify(ignoredStories),
         }),
       );
-      const pathToStorybookConfig = path.resolve(
-        process.cwd(),
-        configDir,
-        'webpack.config.js',
-      );
+      const pathToStorybookConfig = path.resolve(process.cwd(), configDir, 'webpack.config.js');
 
       if (!fs.existsSync(pathToStorybookConfig)) {
         return config;
@@ -28,7 +27,11 @@ module.exports = function happoPluginStorybook({ configDir = '.storybook', ignor
       const storybookWebpackConfig = require(pathToStorybookConfig);
       if (typeof storybookWebpackConfig === 'function') {
         // full control mode
-        return storybookWebpackConfig(config, 'DEVELOPMENT', defaultStorybookConfig(config));
+        return storybookWebpackConfig(
+          config,
+          'DEVELOPMENT',
+          storybookWebpack.createDefaultWebpackConfig(config),
+        );
       }
       config.module.rules.push(...storybookWebpackConfig.module.rules);
       return config;


### PR DESCRIPTION
Fixes error:

```
Creating bundle... TypeError: defaultStorybookConfig is not a function
    at Object.customizeWebpackConfig (/Users/rohandang/dev/consumer/packages/storybook/node_modules/happo-plugin-storybook/index.js:30:62)
    at /Users/rohandang/dev/consumer/packages/storybook/node_modules/happo.io/build/createWebpackBundle.js:74:25
    at Array.forEach (<anonymous>)
    at /Users/rohandang/dev/consumer/packages/storybook/node_modules/happo.io/build/createWebpackBundle.js:72:13
    at Generator.next (<anonymous>)
    at step (/Users/rohandang/dev/consumer/packages/storybook/node_modules/happo.io/build/createWebpackBundle.js:23:191)
    at /Users/rohandang/dev/consumer/packages/storybook/node_modules/happo.io/build/createWebpackBundle.js:23:437
    at new Promise (<anonymous>)
    at /Users/rohandang/dev/consumer/packages/storybook/node_modules/happo.io/build/createWebpackBundle.js:23:99
    at createWebpackBundle (/Users/rohandang/dev/consumer/packages/storybook/node_modules/happo.io/build/createWebpackBundle.js:116:17)
```