### PR TITLE
fix(README): Fix setDefaultDelay import

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ set delays: one global and one per story. Here's an example of setting a global
 delay:
 
 ```js
-import { setDefaultDelay } from 'happo-plugin-storybook';
+import { setDefaultDelay } from 'happo-plugin-storybook/register';
 
 setDefaultDelay(100); // in milliseconds
 ```


### PR DESCRIPTION
if importing from `'happo-plugin-storybook'`, it causes a lot of errors.