### PR TITLE
Handle render exceptions better

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -23,19 +23,35 @@ class AsyncComponent extends React.Component {
 
 setDefaultDelay(1);
 
+window.onbeforeunload = function(e) {
+  throw 'Failed to render because a page load event was fired';
+};
+
 function loadStories() {
   if (!isHappoRun()) {
-    storiesOf('NOT PART OF HAPPO', module).add('default', () => <AsyncComponent />);
+    storiesOf('NOT PART OF HAPPO', module).add('default', () => (
+      <AsyncComponent />
+    ));
   }
   storiesOf('Lazy', module).add('default', () => <AsyncComponent />);
 
   storiesOf('Button', module)
-    .add('with text', () => <Button>Hello Button</Button>, { happo: { delay: 2000 } })
+    .add('with text', () => <Button>Hello Button</Button>, {
+      happo: { delay: 2000 },
+    })
     .add('with image', () => (
       <Button>
         <img src={testImage} />
       </Button>
     ))
+    .add('failing', () => {
+      throw new Error('Some error');
+      return (
+        <Button>
+          <img src={testImage} />
+        </Button>
+      );
+    }, { happo: { delay: 300 } })
     .add('with some emoji', () => (
       <Button>
         <span role="img" aria-label="so cool">

--- a/register.es6.js
+++ b/register.es6.js
@@ -73,10 +73,12 @@ window.happo.nextExample = async () => {
     ReactDOM.render(render(), rootElement);
     await waitForContent(rootElement);
     await new Promise((resolve) => setTimeout(resolve, delay));
-    currentIndex++;
     return { component, variant };
   } catch (e) {
-    throw new Error(`Failed to render ${component} - ${variant}: ${e.message}`);
+    rootElement.innerHTML = `<pre>${e.stack}</pre>`;
+    return { component, variant };
+  } finally {
+    currentIndex++;
   }
 };
 


### PR DESCRIPTION
In IE11, the thrown error never reaches the controlling layer, leading
to a "Script timeout" error. We can deal with this by catching errors,
then rendering the error stack in the DOM (which will get picked up and
screenshot).