### PR TITLE
Try-ignore unmounting React component

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -27,6 +27,15 @@ window.onbeforeunload = function(e) {
   throw 'Failed to render because a page load event was fired';
 };
 
+class UnmountFail extends React.Component {
+  componentWillUnmount() {
+    throw new Error('Failed');
+  }
+  render() {
+    return <span>I throw on unmount</span>;
+  }
+};
+
 function loadStories() {
   if (!isHappoRun()) {
     storiesOf('NOT PART OF HAPPO', module).add('default', () => (
@@ -44,6 +53,11 @@ function loadStories() {
         <img src={testImage} />
       </Button>
     ))
+    .add('failing on unmount', () => {
+      return (
+        <UnmountFail />
+      );
+    })
     .add('failing', () => {
       throw new Error('Some error');
       return (

--- a/register.es6.js
+++ b/register.es6.js
@@ -48,7 +48,12 @@ function getExamples() {
 function cleanup() {
   let rootElement = document.getElementById('happo-plugin-storybook-root');
   if (rootElement) {
-    ReactDOM.unmountComponentAtNode(rootElement);
+    try {
+      ReactDOM.unmountComponentAtNode(rootElement);
+    } catch (e) {
+      // ignore unmount failures
+      console.warn('Failed to unmount React component');
+    }
   }
   document.body.innerHTML = '';
   rootElement = document.createElement('div');


### PR DESCRIPTION
We have a case where the unmount call is throwing an error. While this
might be something we should look into,  it also doesn't really matter
in the happo case, we can just ignore and move on.