### PR TITLE
Add `onBeforeRender` hook

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -5,9 +5,14 @@ import { storiesOf } from '@storybook/react';
 
 import testImage from './testImage.png';
 
-import { setDefaultDelay, isHappoRun } from '../register';
+import { onBeforeRender, setDefaultDelay, isHappoRun } from '../register';
 
 import Button from './src/Button';
+
+let globalState = 'Mexico';
+onBeforeRender(() => {
+  globalState = globalState + '!';
+});
 
 class AsyncComponent extends React.Component {
   componentDidMount() {
@@ -42,6 +47,11 @@ function loadStories() {
       <AsyncComponent />
     ));
   }
+
+  storiesOf('Hooked', module)
+    .add('first render', () => <h1>{globalState}</h1>)
+    .add('second render', () => <h1>{globalState}</h1>);
+
   storiesOf('Lazy', module).add('default', () => <AsyncComponent />);
 
   storiesOf('Button', module)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ storiesOf('FooComponent', module)
   .add('delayed', () => <FooComponent />, { happo: { delay: 200 } });
 ```
 
+If you need to perform some cleanup or initialization in between rendered
+stories, you can use the `onBeforeRender` hook:
+
+```js
+import { onBeforeRender } from 'happo-plugin-storybook/register';
+
+onBeforeRender(() => MockData.clearCaches());
+```
+
 ## Caveats
 
 When you're using this plugin, some of the regular Happo commands and

--- a/register.es6.js
+++ b/register.es6.js
@@ -8,6 +8,7 @@ let examples;
 let currentIndex = 0;
 let rootElement;
 let defaultDelay;
+let beforeRenderHook = () => {};
 
 async function waitForContent(elem, start = new Date().getTime(), attempt = 0) {
   const html = elem.innerHTML.trim();
@@ -55,6 +56,7 @@ function cleanup() {
       console.warn('Failed to unmount React component');
     }
   }
+
   document.body.innerHTML = '';
   rootElement = document.createElement('div');
   rootElement.setAttribute('data-happo-ignore', 'true');
@@ -73,6 +75,12 @@ window.happo.nextExample = async () => {
     return;
   }
   const rootElement = cleanup();
+  try {
+    beforeRenderHook();
+  } catch (e) {
+    // ignore cleanup hook failures
+    console.warn('Failed to execute before render hook');
+  }
   const { component, variant, render, delay } = examples[currentIndex];
   try {
     ReactDOM.render(render(), rootElement);
@@ -89,3 +97,4 @@ window.happo.nextExample = async () => {
 
 export const setDefaultDelay = (delay) => { defaultDelay = delay };
 export const isHappoRun = () => window.top === window.self;
+export const onBeforeRender = (hook) => { beforeRenderHook = hook };


### PR DESCRIPTION
This hook can be used if you want to reset a cache or perform some kind
of initialization in between rendered examples.