### PR TITLE
Remove dependency on react

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,10 +56,6 @@
     "styled-components": "^4.1.3",
     "webpack": "^4.0.0"
   },
-  "peerDependencies": {
-    "@storybook/react": "^3.4.0 || ^4.0.0",
-    "webpack": "^3.0.0 || ^4.0.0"
-  },
   "dependencies": {
     "archiver": "^3.0.0",
     "rimraf": "^2.6.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo-plugin-storybook",
-  "version": "2.0.3",
+  "version": "2.1.0-rc.1",
   "description": "A happo.io plugin for projects using Storybook",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION

So far, this plugin has only been able to render storybook stories
written in React. This limitation was mostly there because all current
users of the plugin were all using React. We can break out of this
dependency by using the event system provided by Storybook.

This change makes the plugin only work for Storybook v4 and later.

The biggest issue I had was around unmount failures. If a component
throws an error on being removed from the DOM, the failure message
ended up on the next rendered example. To work around that, we now
re-render the story if we see an error message after the first render.
This seems to do the trick.
