### PR TITLE
Prevent large stories from breaking subsequent ones

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -53,6 +53,9 @@ function loadStories() {
         <img src={testImage} />
       </Button>
     ))
+    .add('large', () => (
+      <div style={{ width: 400, height: 400, backgroundColor: 'red' }} />
+    ))
     .add('failing on unmount', () => {
       return (
         <UnmountFail />

--- a/register.es6.js
+++ b/register.es6.js
@@ -41,6 +41,20 @@ function getExamples() {
   return result;
 }
 
+function cleanDocument() {
+  [...document.body.children].forEach((node) => {
+    if (node.getAttribute('id') === 'root') {
+      // don't clean out the root node
+      return;
+    }
+    if (node.classList.contains('sb-errordisplay')) {
+      // don't clean out the error container
+      return;
+    }
+    document.body.removeChild(node);
+  });
+}
+
 window.happo = {};
 
 window.happo.nextExample = async () => {
@@ -53,8 +67,7 @@ window.happo.nextExample = async () => {
   const { component, variant, render, delay } = examples[currentIndex];
 
   try {
-    async function renderOnce() {
-    }
+    cleanDocument();
     const rootElement = document.getElementById('root');
     rootElement.setAttribute('data-happo-ignore', 'true');
     __STORYBOOK_ADDONS_CHANNEL__.emit('setCurrentStory', {
@@ -71,6 +84,7 @@ window.happo.nextExample = async () => {
     await new Promise(resolve => setTimeout(resolve, delay));
     return { component, variant };
   } catch (e) {
+    console.warn(e);
     return { component, variant };
   } finally {
     currentIndex++;


### PR DESCRIPTION
In 2.1.0, I introduced a regression that caused screenshots to have the
wrong size. The happo workers inject a div for each example equal to the
size of the content. If we don't clean out that div, the next example
will contain measurements from the measuring div. We should fix this on
happo workers as well, but at least this will unbreak the storybook
plugin.