### PR TITLE
Inject global __IS_HAPPO_RUN variable at build time

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,10 @@ module.exports = function happoStorybookPlugin({
         const iframeContent = fs.readFileSync(iframePath, 'utf-8');
         fs.writeFileSync(iframePath, iframeContent.replace(
           '<head>',
-          '<head><meta name="viewport" content="width=device-width, initial-scale=1">',
+          `<head>
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <script type="text/javascript">window.__IS_HAPPO_RUN = true;</script>
+          `,
         ));
         const buffer = await zipFolderToBuffer(outputDir);
         return buffer.toString('base64');

--- a/register.es6.js
+++ b/register.es6.js
@@ -87,4 +87,4 @@ window.happo.nextExample = async () => {
 export const setDefaultDelay = delay => {
   defaultDelay = delay;
 };
-export const isHappoRun = () => window.top === window.self;
+export const isHappoRun = () => window.__IS_HAPPO_RUN;


### PR DESCRIPTION
Fixes #17.

From the issue description:
  We often open our stories directly (like
  `localhost:9000/iframe.html?...` instead of `localhost:9000/?...`), to
  have the full window preview of the story. (i.e. to open it in
  browserstack or for better developer debugging experience).

  Unfortunately, when opening it in such a way, `isHappoRun` returns
  true (

  [happo-plugin-storybook/register.es6.js](https://github.com/happo/happo-plugin-storybook/blob/d1431b35b4fc234fb89ff0be67f85c087392c3b5/register.es6.js#L97)

  Line 97 in
  [d1431b3](/happo/happo-plugin-storybook/commit/d1431b35b4fc234fb89ff0be67f85c087392c3b5)

   export const isHappoRun = () => window.top === window.self; ).  This
   incorrectly makes our stories to be run in happo mode, when we don't
   want.

Instead of relying on the fact that we're in the iframe, we can inject a
global variable at build time and check it in our register.es6.js. This
is more robust, since we control the injection of the variable.