### PR TITLE
Use original date/time functions defined by happo worker

### DIFF
--- a/register.es6.js
+++ b/register.es6.js
@@ -1,17 +1,22 @@
 import storybookClient from '@storybook/core/client';
 
+const time = window.happoTime || {
+  originalDateNow: Date.now,
+  originalSetTimeout: window.setTimeout.bind(window),
+};
+
 const ASYNC_TIMEOUT = 100;
 
 let examples;
 let currentIndex = 0;
 let defaultDelay;
 
-async function waitForContent(elem, start = new Date().getTime()) {
+async function waitForContent(elem, start = time.originalDateNow()) {
   const html = elem.innerHTML.trim();
-  const duration = new Date().getTime() - start;
+  const duration = time.originalDateNow() - start;
   if (html === '' && duration < ASYNC_TIMEOUT) {
     return new Promise(resolve =>
-      setTimeout(() => resolve(waitForContent(elem, start)), 10),
+      time.originalSetTimeout(() => resolve(waitForContent(elem, start)), 10),
     );
   }
   return html;
@@ -82,7 +87,7 @@ window.happo.nextExample = async () => {
       __STORYBOOK_ADDONS_CHANNEL__.emit('forceReRender');
       await waitForContent(rootElement);
     }
-    await new Promise(resolve => setTimeout(resolve, delay));
+    await new Promise(resolve => time.originalSetTimeout(resolve, delay));
     return { component, variant };
   } catch (e) {
     console.warn(e);


### PR DESCRIPTION
To make it possible to use libraries like sinon.js to freeze time in
your storybook tests, we need to add a little workaround so that we can
access the "real" time when we're waiting for things. Happo workers have been updated to set the `happoTime` global object. We'll use it if it exists, otherwise we fall back to regular functions.