### PR TITLE
Add support for `happo: false` story parameter (in case you want to disable the story on happo env)

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -100,6 +100,9 @@ function loadStories() {
       <AsyncComponent />
     ));
   }
+  storiesOf('ALSO NOT PART OF HAPPO', module).add('default', () => (
+    <AsyncComponent />
+  ), { happo: false });
   storiesOf('Lazy', module).add('default', () => <AsyncComponent />);
   storiesOf('Portal', module).add('default', () => <PortalComponent />);
   storiesOf('Tethered', module).add('default', () => <TetheredComponent />);

--- a/README.md
+++ b/README.md
@@ -57,6 +57,26 @@ if (!isHappoRun()) {
 }
 ```
 
+### Disabling a story
+
+In a perfect case scenario, your stories should be built in such a way that all of them work well in Happo environment. Sometimes though you might want to disable some of the stories in Happo preview, i.e. because they depend on dynamic data that can't be accessed from Happo environment.
+
+In such case you can pass `happo: false` story parameter to it:
+
+```js
+storiesOf('FooComponent', module)
+  .add('Default', () => <FooComponent />);
+  .add('Dynamic', () => <DynamicFooComponent />, { happo: false });
+
+// or
+
+storiesOf('FooComponent', module)
+  .addParameters({ happo: false })
+  .add('Dynamic', () => <DynamicFooComponent />);
+```
+
+### Setting delay for a story
+
 Happo will make its best to wait for your stories to render, but at times you
 might need a little more control in the form of delays. There are two ways to
 set delays: one global and one per story. Here's an example of setting a global

--- a/register.es6.js
+++ b/register.es6.js
@@ -34,6 +34,9 @@ function getExamples() {
         const {
           parameters: { happo = {} },
         } = storyStore.getStoryAndParameters(story.kind, variant);
+        if (happo === false) {
+          continue;
+        }
         delay = happo.delay || defaultDelay;
       }
 


### PR DESCRIPTION
This solves https://github.com/happo/happo-plugin-storybook/issues/19 .

This change is backward compatible.

This lets you instead of doing

```js
if (!isHappoRun()) {
  stories.add('Single Video', () => (
    <GalleryLightboxStory items={[buildVideoItem(32)]} />
  ));
}
```

do

```js
stories.add(
  'Single Video',
  () => <GalleryLightboxStory items={[buildVideoItem(32)]} />,
  { happo: false },
);
```

or

```js
stories
  .addParameters({ happo: false })
  .add('Single Video', () => (
    <GalleryLightboxStory items={[buildVideoItem(32)]} />
  ));
```