### PR TITLE
Fix invoking build-storybook command in windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ module.exports = function happoStorybookPlugin({
           params,
           {
             stdio: 'inherit',
+            shell: process.platform == 'win32',
           },
         );
 


### PR DESCRIPTION
I finally got a proper repro case for some issues we're seeing in
windows environments. I found a similar SO thread and the fix was to use
the `shell` option for spawn:
https://stackoverflow.com/a/54515183