### PR TITLE
Add `usePrebuiltPackage` option

### DIFF
--- a/.happo.js
+++ b/.happo.js
@@ -33,6 +33,7 @@ module.exports = {
       configDir: '.storybook',
       outputDir: '.happo-out',
       staticDir: 'public',
+      usePrebuiltPackage: !!process.env.HAPPO_USE_PREBUILT_PACKAGE,
     }),
   ],
   stylesheets: [path.resolve(__dirname, 'test.css')],

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ node_js:
 env:
   - SB_V=5
   - SB_V=6
+  - SB_V=6 HAPPO_USE_PREBUILT_PACKAGE=yes
 install: yarn install
-script: yarn add @storybook/addons@${SB_V} @storybook/react@${SB_V} && rm -rf node_modules && yarn install && yarn build && yarn happo run
+script: yarn add @storybook/addons@${SB_V} @storybook/react@${SB_V} && rm -rf node_modules && yarn install && yarn build && yarn build-storybook && yarn happo run

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "happo": "happo",
     "build": "babel register.es6.js --out-file register.js",
     "prepublish": "yarn build",
-    "storybook": "start-storybook -p 9001 -c .storybook -s public"
+    "storybook": "start-storybook -p 9001 -c .storybook -s public",
+    "build-storybook": "build-storybook -c .storybook -o .happo-out -s public"
   },
   "jest": {
     "testMatch": [


### PR DESCRIPTION
This new option will allow people to reuse an already existing storybook
build. This can help speed up certain CI setups, where the package can
be built once and then different consumers can make use of it.