### PR TITLE
Add ability to click element before screenshot

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import TetherComponent from 'react-tether';
 import { configure } from '@storybook/react';
@@ -114,6 +114,14 @@ class AsyncContent extends React.Component {
   }
 }
 
+function ClickToReveal() {
+  const [open, setOpen] = useState(false);
+  if (open) {
+    return <div>I'm open</div>;
+  }
+  return <button onClick={() => setOpen(true)}>Open</button>;
+}
+
 function loadStories() {
   if (!isHappoRun()) {
     storiesOf('NOT PART OF HAPPO', module).add('default', () => (
@@ -125,6 +133,18 @@ function loadStories() {
     () => <AsyncComponent />,
     { happo: false },
   );
+  storiesOf('ClickToReveal', module).add('default', () => <ClickToReveal />, {
+    happo: {
+      beforeScreenshot: () => {
+        const clickEvent = new MouseEvent('click', {
+          view: window,
+          bubbles: true,
+          cancelable: false,
+        });
+        document.querySelector('button').dispatchEvent(clickEvent);
+      },
+    },
+  });
   storiesOf('Lazy', module).add('default', () => <AsyncComponent />);
   storiesOf('Portal', module).add('default', () => <PortalComponent />);
   storiesOf('Tethered', module).add('default', () => <TetheredComponent />);

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "file-loader": "^3.0.1",
     "happo.io": "^5.1.3",
     "raw-loader": "^1.0.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "react-tether": "^2.0.0",
     "styled-components": "^4.1.3",
     "webpack": "^4.0.0"

--- a/register.es6.js
+++ b/register.es6.js
@@ -49,10 +49,12 @@ function getExamples() {
         let delay = defaultDelay;
         let waitForContent;
         let waitFor;
+        let beforeScreenshot;
         if (typeof parameters.happo === 'object' && parameters.happo !== null) {
           delay = parameters.happo.delay || defaultDelay;
           waitForContent = parameters.happo.waitForContent;
           waitFor = parameters.happo.waitFor;
+          beforeScreenshot = parameters.happo.beforeScreenshot;
         }
         return {
           component: kind,
@@ -61,6 +63,7 @@ function getExamples() {
           delay,
           waitForContent,
           waitFor,
+          beforeScreenshot,
         };
       })
       .filter(Boolean);
@@ -87,6 +90,7 @@ function getExamples() {
           delay = parameters.happo.delay || defaultDelay;
           waitForContent = parameters.happo.waitForContent;
           waitFor = parameters.happo.waitFor;
+          beforeScreenshot = parameters.happo.beforeScreenshot;
         }
       }
 
@@ -102,6 +106,7 @@ function getExamples() {
         storyId,
         waitForContent,
         waitFor,
+        beforeScreenshot,
       });
     }
   }
@@ -125,9 +130,15 @@ window.happo.nextExample = async () => {
   if (currentIndex >= examples.length) {
     return;
   }
-  const { component, variant, storyId, delay, waitForContent, waitFor } = examples[
-    currentIndex
-  ];
+  const {
+    component,
+    variant,
+    storyId,
+    delay,
+    waitForContent,
+    waitFor,
+    beforeScreenshot,
+  } = examples[currentIndex];
 
   try {
     const docsRootElement = document.getElementById('docs-root');
@@ -152,6 +163,9 @@ window.happo.nextExample = async () => {
     await new Promise(resolve => time.originalSetTimeout(resolve, delay));
     if (waitFor) {
       await waitForWaitFor(waitFor);
+    }
+    if (beforeScreenshot && typeof beforeScreenshot === 'function') {
+      beforeScreenshot({ rootElement });
     }
     return { component, variant, waitForContent };
   } catch (e) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9504,6 +9504,15 @@ react-dom@^16.8.3:
     prop-types "^15.6.2"
     scheduler "^0.18.0"
 
+react-dom@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
+  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    scheduler "^0.20.2"
+
 react-draggable@^4.0.3:
   version "4.2.0"
   resolved "https://registry.npmjs.org/react-draggable/-/react-draggable-4.2.0.tgz#40cc5209082ca7d613104bf6daf31372cc0e1114"
@@ -9627,6 +9636,14 @@ react@^16.8.3:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
+
+react@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 reactcss@^1.2.0:
   version "1.2.3"
@@ -10078,6 +10095,14 @@ scheduler@^0.18.0:
   version "0.18.0"
   resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz#5901ad6659bc1d8f3fdaf36eb7a67b0d6746b1c4"
   integrity sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
A generic `beforeScreenshot` hook is added so that people can add simple
user interaction before the screenshot is taken. This will allow buttons
to be clicked, text to be entered, etc.