### PR TITLE
Add async story that uses a data-attribute

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
+      HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
 
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Run tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        storybook-version: [5, 6]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 14
+      uses: actions/setup-node@v2
+      with:
+        node-version: 14
+    - run: yarn install --frozen-lockfile
+    - run: yarn add @storybook/addons@${{ matrix.storybook-version }} @storybook/react@${{ matrix.storybook-version }} && rm -rf node_modules && yarn install && yarn build && yarn happo run
+    - run: HAPPO_USE_PREBUILT_PACKAGE=yes yarn build-storybook && yarn happo run

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -114,6 +114,20 @@ class AsyncContent extends React.Component {
   }
 }
 
+function Async2 () {
+  const [ready, setReady] = React.useState(false);
+  React.useEffect(() => {
+    setTimeout(() => {
+      setReady(true);
+    }, 1000);
+  }, []);
+  return (
+    <div data-async-ready={ready}>
+      <h1>{ready ? 'Ready' : 'Not ready'}</h1>
+    </div>
+  );
+}
+
 function ClickToReveal() {
   const [open, setOpen] = useState(false);
   if (open) {
@@ -190,6 +204,9 @@ function loadStories() {
       happo: { delay: 1200 },
     });
 
+  storiesOf('Async2', module).add('attribute selector', () => <Async2 />, {
+    happo: { waitFor: () => document.querySelector('[data-async-ready=true]') },
+  });
   storiesOf('Button', module)
     .add('with text', () => <Button>Hello Button</Button>, {
       happo: { delay: 2000 },

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-node_js:
-  - '12'
-env:
-  - SB_V=5
-  - SB_V=6
-  - SB_V=6 HAPPO_USE_PREBUILT_PACKAGE=yes
-install: yarn install
-script: yarn add @storybook/addons@${SB_V} @storybook/react@${SB_V} && rm -rf node_modules && yarn install && yarn build && yarn build-storybook && yarn happo run


### PR DESCRIPTION
I'm currently debugging an issue with a `waitFor` that isn't working
consistently in Firefox. I believe this story is a good repro case and
I'm hoping it will showcase the spurious behavior we've seen in a
different happo test suite.