### PR TITLE
Revert "Move @storybook/core dependency to devDependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@mui/material": "^5.8.0",
     "@storybook/addon-interactions": "^6.5.5",
     "@storybook/addons": "^6.5.5",
-    "@storybook/core": "^6.5.5",
     "@storybook/react": "^6.5.5",
     "@storybook/testing-library": "^0.0.11",
     "babel-loader": "^8.0.5",
@@ -70,6 +69,7 @@
   },
   "dependencies": {
     "@babel/runtime": ">=7.0.0",
+    "@storybook/core": "^6.5.5",
     "archiver": "^3.0.0",
     "rimraf": "^2.6.3"
   }


### PR DESCRIPTION
This reverts commit 23759c3935abbd8973b20d9e4cf06652f5f2167a.

### Configuration
<img width="307" alt="Screenshot 2022-06-14 at 17 43 49" src="https://user-images.githubusercontent.com/17122466/173606449-4d041004-fc31-4f1e-9e83-d06fb97e8b90.png">

### Description of the issue
[The register hook](https://docs.happo.io/docs/storybook#configuration) `import "happo-plugin-storybook/register"` depends on `@storybook/core` to be [installed](https://github.com/happo/happo-plugin-storybook/blob/master/register.es6.js#L1).

Having `@storybook/core` declared in `devDependencies` ends in an error that module cannot be found.
<img width="773" alt="Screenshot 2022-06-14 at 17 40 43" src="https://user-images.githubusercontent.com/17122466/173606583-9ec568d3-7676-416f-97f4-d7f0cf8305fe.png">

The modern storybook [resolves](https://github.com/storybookjs/storybook/tree/v6.5.8/lib/core) its `core` dependency as
`node_modules/@storybook/core-client` and `node_modules/@storybook/core-server`, etc.
<details>
<summary>show/hide</summary>

<img width="399" alt="Screenshot 2022-06-14 at 17 43 28" src="https://user-images.githubusercontent.com/17122466/173606361-eff771cc-55c0-4715-8877-87cc476d59a4.png">

</details>

So the issue could be fixed via one of the following options:
1) Reverting this commit
2) Explicitly adding `@storybook/core` to the project dependencies
3) Resolving `core/client` as `core-client` in `.storybook/main.js`
```ts
webpackFinal: async (config) => {
  config.resolve.alias["@storybook/core/client"] = "@storybook/core-client";
  return config;
}
```