### PR TITLE
Add support for themes

### DIFF
--- a/.storybook/Story.stories.js
+++ b/.storybook/Story.stories.js
@@ -52,8 +52,8 @@ function TetheredComponent() {
   return (
     <TetherComponent
       attachment="top left"
-      renderTarget={ref => <button ref={ref}>I'm the target</button>}
-      renderElement={ref => (
+      renderTarget={(ref) => <button ref={ref}>I'm the target</button>}
+      renderElement={(ref) => (
         <div ref={ref} style={{ border: '1px solid red', padding: 10 }}>
           <h2>Tethered Content</h2>
           <p>A paragraph to accompany the title.</p>
@@ -134,6 +134,13 @@ function ClickToReveal() {
   }
   return <button onClick={() => setOpen(true)}>Open</button>;
 }
+
+export const Themed = () => (
+  <div style={{ color: 'gray' }}>My color is gray</div>
+);
+Themed.parameters = {
+  happo: { themes: ['black', 'white'] },
+};
 
 export const NotPartOfHappo = () => <AsyncComponent />;
 NotPartOfHappo.parameters = { happo: false };
@@ -247,7 +254,7 @@ WithTooltip.parameters = {
         }),
       );
       // delay with 200ms to allow the animation to finish
-      await new Promise(r => setTimeout(r, 200));
+      await new Promise((r) => setTimeout(r, 200));
     },
   },
 };

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,1 +1,9 @@
-import '../register';
+import { setThemeSwitcher } from '../register';
+
+setThemeSwitcher(async (theme, channel) => {
+  // Make sure that it can be async
+  await new Promise(r => setTimeout(r, 100));
+
+  document.body.style = `background-color: ${theme}`;
+});
+


### PR DESCRIPTION
Based on the work that @juliepagano has done in
https://github.com/perses/perses/pull/991, I'm extracting some logic and making it possible to split up certain stories for multiple themes. The idea is that you can configure `happo: { themes: ['light', 'dark'] }` on your story and have Happo render both themes (adapting the variant name to include the theme).

To make happo-plugin-storybook unaware of dark mode, the storybook-dark-mode library and similar implementation details, I decided to introduce a new option for the register module, setThemeSwitcher. You configure Happo with a theme switcher function, e.g.

```
import { setThemeSwitcher } from '../register';

setThemeSwitcher(async (theme, channel) => {
  return new Promise((resolve) => {
    const isDarkMode = theme === 'dark';

    // Listen for dark mode to change and resolve.
    channel.once(DARK_MODE_EVENT_NAME, () => {
      resolve();
    });
    // Change the theme.
    channel.emit(DARK_MODE_EVENT_NAME, isDarkMode);
  });
});
```

For now, I'm not dealing with cleanup of themes. This means that you'll probably have to give each story at least one theme so that a previous one isn't kept active from an earlier story. The best way to do that is to add a default `happo: { themes: [...] }` config with at least one theme name.