### PR TITLE
Wait for storybook render phase to be "completed"

### DIFF
--- a/.storybook/Interactive.stories.js
+++ b/.storybook/Interactive.stories.js
@@ -22,6 +22,7 @@ export default {
 export const Demo = {
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
+    await new Promise((r) => setTimeout(r, 400));
     await userEvent.click(canvas.getByRole('button'));
   },
 };

--- a/src/register.js
+++ b/src/register.js
@@ -127,6 +127,22 @@ window.happo.init = (config) => {
   initConfig = config;
 };
 
+function renderStory(story) {
+  const channel = window.__STORYBOOK_ADDONS_CHANNEL__;
+  return new Promise((resolve) => {
+    const timeout = setTimeout(resolve, WAIT_FOR_TIMEOUT);
+    function handleRenderPhaseChanged(ev) {
+      if (ev.newPhase === 'completed') {
+        channel.off('storyRenderPhaseChanged', handleRenderPhaseChanged);
+        clearTimeout(timeout);
+        return resolve();
+      }
+    }
+    channel.on('storyRenderPhaseChanged', handleRenderPhaseChanged);
+    channel.emit('setCurrentStory', story);
+  });
+}
+
 window.happo.nextExample = async () => {
   if (!examples) {
     examples = filterExamples(await getExamples());
@@ -161,12 +177,11 @@ window.happo.nextExample = async () => {
         console.error('Failed to invoke afterScreenshot hook', e);
       }
     }
-    window.__STORYBOOK_ADDONS_CHANNEL__.emit('setCurrentStory', {
+    await renderStory({
       kind: component,
       story: variant,
       storyId,
     });
-    await new Promise((resolve) => time.originalSetTimeout(resolve, 0));
     if (theme && themeSwitcher) {
       await themeSwitcher(theme, window.__STORYBOOK_ADDONS_CHANNEL__);
     }


### PR DESCRIPTION
This should help prevent taking screenshots too early when you have play interactions that are asynchronous.