### PR TITLE
Make render timeout configurable

### DIFF
--- a/.storybook/Interactive.stories.js
+++ b/.storybook/Interactive.stories.js
@@ -22,7 +22,7 @@ export default {
 export const Demo = {
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
-    await new Promise((r) => setTimeout(r, 400));
+    await new Promise((r) => setTimeout(r, 3000));
     await userEvent.click(canvas.getByRole('button'));
   },
 };

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,4 @@
-import { setThemeSwitcher } from '../register';
+import { setThemeSwitcher, setRenderTimeoutMs } from '../register';
 
 setThemeSwitcher(async (theme, channel) => {
   // Make sure that it can be async
@@ -7,3 +7,4 @@ setThemeSwitcher(async (theme, channel) => {
   document.body.style = `background-color: ${theme}`;
 });
 
+setRenderTimeoutMs(4000);

--- a/src/register.js
+++ b/src/register.js
@@ -6,8 +6,8 @@ const time = window.happoTime || {
 };
 
 const ASYNC_TIMEOUT = 100;
-const WAIT_FOR_TIMEOUT = 2000;
 
+let renderTimeoutMs = 2000;
 let examples;
 let currentIndex = 0;
 let defaultDelay;
@@ -29,7 +29,7 @@ async function waitForSomeContent(elem, start = time.originalDateNow()) {
 
 async function waitForWaitFor(waitFor, start = time.originalDateNow()) {
   const duration = time.originalDateNow() - start;
-  if (!waitFor() && duration < WAIT_FOR_TIMEOUT) {
+  if (!waitFor() && duration < renderTimeoutMs) {
     return new Promise((resolve) =>
       time.originalSetTimeout(
         () => resolve(waitForWaitFor(waitFor, start)),
@@ -130,7 +130,7 @@ window.happo.init = (config) => {
 function renderStory(story) {
   const channel = window.__STORYBOOK_ADDONS_CHANNEL__;
   return new Promise((resolve) => {
-    const timeout = time.originalSetTimeout(resolve, WAIT_FOR_TIMEOUT);
+    const timeout = time.originalSetTimeout(resolve, renderTimeoutMs);
     function handleRenderPhaseChanged(ev) {
       if (ev.newPhase === 'completed') {
         channel.off('storyRenderPhaseChanged', handleRenderPhaseChanged);
@@ -225,6 +225,9 @@ window.happo.nextExample = async () => {
 
 export const setDefaultDelay = (delay) => {
   defaultDelay = delay;
+};
+export const setRenderTimeoutMs = (timeoutMs) => {
+  renderTimeoutMs = timeoutMs;
 };
 export const setThemeSwitcher = (func) => {
   themeSwitcher = func;


### PR DESCRIPTION
With interactive stories, there's a chance the play function takes longer than 2 seconds to finish (e.g. when using userEvent.type). The 2 second timeout might then be too short. To allow people to work around this, I'm allowing this timeout to be configurable via a `setRenderTimeoutMs` function exported by register.js.

Fixes #97