### PR TITLE
Sort stories so that themes are separate

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,9 +2,17 @@ import { setThemeSwitcher, setRenderTimeoutMs } from '../register';
 
 setThemeSwitcher(async (theme, channel) => {
   // Make sure that it can be async
-  await new Promise(r => setTimeout(r, 100));
+  await new Promise((r) => setTimeout(r, 100));
 
   document.body.style = `background-color: ${theme}`;
 });
 
 setRenderTimeoutMs(4000);
+
+export default {
+  parameters: {
+    happo: {
+      themes: ['white'],
+    },
+  },
+};

--- a/src/register.js
+++ b/src/register.js
@@ -97,7 +97,15 @@ async function getExamples() {
       }
 
       return result;
-    }, []);
+    }, [])
+    .sort((a, b) => {
+      const aCompare = `${a.theme}-${a.storyId}`;
+      const bCompare = `${b.theme}-${b.storyId}`;
+      if (aCompare === bCompare) {
+        return 0;
+      }
+      return aCompare < bCompare ? -1 : 1;
+    });
 }
 
 function filterExamples(all) {


### PR DESCRIPTION
We're seeing issues with rendering the same story with a different theme right after the same story rendering in one theme. It looks like things are behaving better if I avoid rendering the same story with a different theme right after each other, so I'm sorting stories based on theme before we start.