### PR TITLE
Improve checking for Storybook v7

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,18 @@ function resolveBuildCommandParts() {
     }
   }
   try {
+    execSync(`${binary} storybook --version`);
+    // Storybook v7 or later
+    return ['storybook', 'build'];
+  } catch (e) {
+    if (HAPPO_DEBUG) {
+      console.log(
+        '[happo] Check for Storybook v7 failed. Details:',
+        e,
+      );
+    }
+  }
+  try {
     execSync(`${binary} build-storybook --version`);
     return ['build-storybook'];
   } catch (e) {


### PR DESCRIPTION
I came across a case where Storybook 7 was used but the plugin still detected v6. Going to add another v7 check to make things more robust.