### PR TITLE
Listen to `completed` storyRenderPhaseChanged event by default

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -13,6 +13,7 @@ let currentIndex = 0;
 let defaultDelay;
 let themeSwitcher;
 let forcedHappoScreenshotSteps;
+let shouldWaitForCompletedEvent = true;
 
 async function waitForSomeContent(elem, start = time.originalDateNow()) {
   const html = elem.innerHTML.trim();
@@ -165,9 +166,6 @@ function renderStory(story, { force = false } = {}) {
       }
     }
 
-    const shouldWaitForCompletedEvent = (channel.events || {})
-      .storyRenderPhaseChanged;
-
     if (shouldWaitForCompletedEvent) {
       channel.on('storyRenderPhaseChanged', handleRenderPhaseChanged);
     }
@@ -301,13 +299,16 @@ export function forceHappoScreenshot(stepLabel) {
   throw e;
 }
 
-export const setDefaultDelay = (delay) => {
+export function setDefaultDelay(delay) {
   defaultDelay = delay;
-};
-export const setRenderTimeoutMs = (timeoutMs) => {
+}
+export function setRenderTimeoutMs(timeoutMs) {
   renderTimeoutMs = timeoutMs;
-};
-export const setThemeSwitcher = (func) => {
+}
+export function setThemeSwitcher(func) {
   themeSwitcher = func;
-};
+}
+export function setShouldWaitForCompletedEvent(swfce) {
+  shouldWaitForCompletedEvent = swfce;
+}
 export const isHappoRun = () => window.__IS_HAPPO_RUN;


### PR DESCRIPTION
And allow people to disable the behavior by calling `setShouldWaitForCompletedEvent(false)`.

At first I was trying to find a feature-detection method of knowing when this event was present or not. But it turned out that was quite hard. So I went the simpler route by defaulting the variable to true and then allowing people to override it in case they are on Storybook earlier than v6.4.0.

The issue with the previous feature detection approach was that we relied on a listener for the event to be set up elsewhere. If no listener were in place for storyRenderPhaseChanged, we wouldn't use it. In most cases, the listener is there, but we've just come across a Storybook where that's not the case.

Fixes https://github.com/happo/happo-plugin-storybook/issues/105