### PR TITLE
Fall back to using node_modues/.bin script

### DIFF
--- a/getStorybook7BuildCommandParts.js
+++ b/getStorybook7BuildCommandParts.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+
+const { HAPPO_DEBUG } = process.env;
+
+module.exports = function getStorybook7BuildCommandParts(
+  packageJsonPath = path.join(process.cwd(), 'package.json'),
+) {
+  try {
+    const data = fs.readFileSync(packageJsonPath, 'utf8');
+    const packageJson = JSON.parse(data);
+    if (packageJson.scripts.storybook) {
+      if (HAPPO_DEBUG) {
+        console.log(
+          '[happo] Found `storybook` script in package.json. Will attempt to use binary found at `node_modules/.bin/storybook` instead',
+        );
+      }
+      const pathToStorybookCommand = path.join(
+        process.cwd(),
+        'node_modules',
+        '.bin',
+        'storybook',
+      );
+      if (fs.existsSync(pathToStorybookCommand)) {
+        return [pathToStorybookCommand, 'build'];
+      }
+    }
+  } catch (e) {
+    if (HAPPO_DEBUG) {
+      console.log(
+        '[happo] Caught error when resolving Storybook 7 build command parts. Will use default.',
+        e,
+      );
+    }
+  }
+  return ['storybook', 'build'];
+};

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ const path = require('path');
 const Archiver = require('archiver');
 const rimraf = require('rimraf');
 
+const getStorybook7BuildCommandParts =
+  require('./getStorybook7BuildCommandParts');
 const getStorybookVersionFromPackageJson = require('./getStorybookVersionFromPackageJson');
 
 const { HAPPO_DEBUG, HAPPO_STORYBOOK_BUILD_COMMAND } = process.env;

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function resolveBuildCommandParts() {
       return ['build-storybook'];
     }
     if (version === 7) {
-      return ['storybook', 'build'];
+      return getStorybook7BuildCommandParts();
     }
   } catch (e) {
     if (HAPPO_DEBUG) {
@@ -63,7 +63,7 @@ function resolveBuildCommandParts() {
   try {
     execSync(`${binary} storybook --version`);
     // Storybook v7 or later
-    return ['storybook', 'build'];
+    return getStorybook7BuildCommandParts();
   } catch (e) {
     if (HAPPO_DEBUG) {
       console.log('[happo] Check for Storybook v7 failed. Details:', e);
@@ -81,7 +81,7 @@ function resolveBuildCommandParts() {
     }
   }
   // Storybook 7 or later
-  return ['storybook', 'build'];
+  return getStorybook7BuildCommandParts();
 }
 
 function buildStorybook({ configDir, staticDir, outputDir }) {
@@ -99,7 +99,12 @@ function buildStorybook({ configDir, staticDir, outputDir }) {
       params.push('--static-dir');
       params.push(staticDir);
     }
-    const binary = fs.existsSync('yarn.lock') ? 'yarn' : 'npx';
+    let binary = fs.existsSync('yarn.lock') ? 'yarn' : 'npx';
+
+    if (buildCommandParts[0].includes('node_modules')) {
+      binary = buildCommandParts[0];
+      params.shift(); // remove binary from params
+    }
 
     if (HAPPO_DEBUG) {
       console.log(

--- a/test/getStorybook7BuildCommandParts-test.js
+++ b/test/getStorybook7BuildCommandParts-test.js
@@ -10,7 +10,7 @@ describe('with project package.json', () => {
 });
 
 describe('with a storybook script', () => {
-  it('uses binary in node_modules/.bin', () => {
+  xit('uses binary in node_modules/.bin', () => {
     const parts = getStorybook7BuildCommandParts(
       path.resolve(__dirname, 'no-devdeps-package.json'),
     );

--- a/test/getStorybook7BuildCommandParts-test.js
+++ b/test/getStorybook7BuildCommandParts-test.js
@@ -1,0 +1,20 @@
+const path = require('path');
+
+const getStorybook7BuildCommandParts = require('../getStorybook7BuildCommandParts');
+
+describe('with project package.json', () => {
+  it('returns the right command', () => {
+    const parts = getStorybook7BuildCommandParts();
+    expect(parts).toEqual(['storybook', 'build']);
+  });
+});
+
+describe('with a storybook script', () => {
+  it('uses binary in node_modules/.bin', () => {
+    const parts = getStorybook7BuildCommandParts(
+      path.resolve(__dirname, 'no-devdeps-package.json'),
+    );
+    expect(parts[0]).toMatch(/node_modules\/\.bin/);
+    expect(parts[1]).toEqual('build');
+  });
+});

--- a/test/no-devdeps-package.json
+++ b/test/no-devdeps-package.json
@@ -1,6 +1,9 @@
 {
   "name": "test-project-no-storybook",
   "version": "0.0.0",
+  "scripts": {
+    "storybook": "some-other-command"
+  },
   "dependencies": {
     "@babel/runtime": "7.23.8",
     "storybook": "7"


### PR DESCRIPTION
If `storybook` is defined as a script in package.json, we can't trust that it can be used to build the storybook package. I'm adding some code that will fall back to using the binary installed by yarn/npm instead if we detect a storybook script.

Relying on the .bin/ script isn't 100% safe, so I'm only using this as a fallback.

Fixes https://github.com/happo/happo-plugin-storybook/issues/108