### PR TITLE
Stop using base64 packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
-const { Writable } = require('stream');
 const { spawn, execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-const Archiver = require('archiver');
 const rimraf = require('rimraf');
 
 const getStorybook7BuildCommandParts =
@@ -11,26 +9,6 @@ const getStorybook7BuildCommandParts =
 const getStorybookVersionFromPackageJson = require('./getStorybookVersionFromPackageJson');
 
 const { HAPPO_DEBUG, HAPPO_STORYBOOK_BUILD_COMMAND } = process.env;
-
-function zipFolderToBuffer(outputDir) {
-  return new Promise((resolve, reject) => {
-    const archive = new Archiver('zip');
-    const stream = new Writable();
-    const data = [];
-    stream._write = (chunk, enc, done) => {
-      data.push(...chunk);
-      done();
-    };
-    stream.on('finish', () => {
-      const buffer = Buffer.from(data);
-      resolve(buffer);
-    });
-    archive.pipe(stream);
-    archive.directory(outputDir, '');
-    archive.on('error', reject);
-    archive.finalize();
-  });
-}
 
 function resolveBuildCommandParts() {
   if (HAPPO_STORYBOOK_BUILD_COMMAND) {
@@ -157,8 +135,8 @@ module.exports = function happoStorybookPlugin({
           `,
           ),
         );
-        const buffer = await zipFolderToBuffer(outputDir);
-        return buffer.toString('base64');
+        // Tell happo.io where the files are located.
+        return { path: outputDir };
       } catch (e) {
         console.error(e);
         throw e;

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
   },
   "dependencies": {
     "@babel/runtime": ">=7.0.0",
-    "archiver": "^3.0.0",
     "rimraf": "^2.6.3"
   },
   "packageManager": "yarn@4.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5902,21 +5902,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"archiver@npm:^3.0.0":
-  version: 3.1.1
-  resolution: "archiver@npm:3.1.1"
-  dependencies:
-    archiver-utils: "npm:^2.1.0"
-    async: "npm:^2.6.3"
-    buffer-crc32: "npm:^0.2.1"
-    glob: "npm:^7.1.4"
-    readable-stream: "npm:^3.4.0"
-    tar-stream: "npm:^2.1.0"
-    zip-stream: "npm:^2.1.2"
-  checksum: 10c0/cbe672f5abcafcf5018241e65e186839b4d5881a5ea7e3829a5946a12ca9a053bd7af1817791e14e518e391b7255b5ccf4f443a0f743d312ec2583263a74b493
-  languageName: node
-  linkType: hard
-
 "archiver@npm:^5.0.2":
   version: 5.3.2
   resolution: "archiver@npm:5.3.2"
@@ -6107,15 +6092,6 @@ __metadata:
   dependencies:
     retry: "npm:0.13.1"
   checksum: 10c0/cabced4fb46f8737b95cc88dc9c0ff42656c62dc83ce0650864e891b6c155a063af08d62c446269b51256f6fbcb69a6563b80e76d0ea4a5117b0c0377b6b19d8
-  languageName: node
-  linkType: hard
-
-"async@npm:^2.6.3":
-  version: 2.6.4
-  resolution: "async@npm:2.6.4"
-  dependencies:
-    lodash: "npm:^4.17.14"
-  checksum: 10c0/0ebb3273ef96513389520adc88e0d3c45e523d03653cc9b66f5c46f4239444294899bfd13d2b569e7dbfde7da2235c35cf5fd3ece9524f935d41bbe4efccdad0
   languageName: node
   linkType: hard
 
@@ -6765,7 +6741,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer@npm:^5.1.0, buffer@npm:^5.5.0":
+"buffer@npm:^5.5.0":
   version: 5.7.1
   resolution: "buffer@npm:5.7.1"
   dependencies:
@@ -7295,18 +7271,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"compress-commons@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "compress-commons@npm:2.1.1"
-  dependencies:
-    buffer-crc32: "npm:^0.2.13"
-    crc32-stream: "npm:^3.0.1"
-    normalize-path: "npm:^3.0.0"
-    readable-stream: "npm:^2.3.6"
-  checksum: 10c0/f16551f9130a5c8762f1436f087f8c2e37646fbff3cf4e0dc254523d71e2979df910797a45279fced487dd341760f34654e6a54857bcf97c019bf8d3cae814a6
-  languageName: node
-  linkType: hard
-
 "compress-commons@npm:^4.1.2":
   version: 4.1.2
   resolution: "compress-commons@npm:4.1.2"
@@ -7495,16 +7459,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"crc32-stream@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "crc32-stream@npm:3.0.1"
-  dependencies:
-    crc: "npm:^3.4.4"
-    readable-stream: "npm:^3.4.0"
-  checksum: 10c0/cf026cc08e68a7eb9f9245b3937d062339a54c2f5b4738c7fb861bd2db56ac220df3627f02ed6e0972633a99435d409f4470cf0a3aac6e944d87730493b6dea0
-  languageName: node
-  linkType: hard
-
 "crc32-stream@npm:^4.0.2":
   version: 4.0.3
   resolution: "crc32-stream@npm:4.0.3"
@@ -7512,15 +7466,6 @@ __metadata:
     crc-32: "npm:^1.2.0"
     readable-stream: "npm:^3.4.0"
   checksum: 10c0/127b0c66a947c54db37054fca86085722140644d3a75ebc61d4477bad19304d2936386b0461e8ee9e1c24b00e804cd7c2e205180e5bcb4632d20eccd60533bc4
-  languageName: node
-  linkType: hard
-
-"crc@npm:^3.4.4":
-  version: 3.8.0
-  resolution: "crc@npm:3.8.0"
-  dependencies:
-    buffer: "npm:^5.1.0"
-  checksum: 10c0/1a0da36e5f95b19cd2a7b2eab5306a08f1c47bdd22da6f761ab764e2222e8e90a877398907cea94108bd5e41a6d311ea84d7914eaca67da2baa4050bd6384b3d
   languageName: node
   linkType: hard
 
@@ -9819,7 +9764,6 @@ __metadata:
     "@storybook/react": "npm:^8.0.0"
     "@storybook/react-webpack5": "npm:^8.0.0"
     "@storybook/test": "npm:^8.0.0"
-    archiver: "npm:^3.0.0"
     babel-loader: "npm:^8.0.5"
     eslint: "npm:^8.6.0"
     eslint-plugin-jest: "npm:^27.6.3"
@@ -11921,7 +11865,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.11, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.7.0":
+"lodash@npm:^4.17.11, lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.7.0":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
@@ -15282,7 +15226,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar-stream@npm:^2.1.0, tar-stream@npm:^2.1.4, tar-stream@npm:^2.2.0":
+"tar-stream@npm:^2.1.4, tar-stream@npm:^2.2.0":
   version: 2.2.0
   resolution: "tar-stream@npm:2.2.0"
   dependencies:
@@ -16561,17 +16505,6 @@ __metadata:
   version: 1.0.0
   resolution: "yocto-queue@npm:1.0.0"
   checksum: 10c0/856117aa15cf5103d2a2fb173f0ab4acb12b4b4d0ed3ab249fdbbf612e55d1cadfd27a6110940e24746fb0a78cf640b522cc8bca76f30a3b00b66e90cf82abe0
-  languageName: node
-  linkType: hard
-
-"zip-stream@npm:^2.1.2":
-  version: 2.1.3
-  resolution: "zip-stream@npm:2.1.3"
-  dependencies:
-    archiver-utils: "npm:^2.1.0"
-    compress-commons: "npm:^2.1.1"
-    readable-stream: "npm:^3.4.0"
-  checksum: 10c0/aac673670f9aa673cf6c8d99e010d6c99ab08deb80f919a0bc537d0c914ea640cb5aae1bbd84348dfa586693eab0bb62829d1c3033f163b489f9f08317fc954c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The happo.io library is already supporting a less memory-intense strategy, involving using a path to a directory.

https://github.com/happo/happo.io/blob/e41980696df1dba1c9f1dbdb7ec3705a6b6b8e56/src/remoteRunner.js#L33