### PR TITLE
Add support for skipping examples

### DIFF
--- a/.happo.js
+++ b/.happo.js
@@ -37,6 +37,14 @@ module.exports = {
       configDir: '.storybook',
       outputDir: '.happo-out',
       usePrebuiltPackage: !!process.env.HAPPO_USE_PREBUILT_PACKAGE,
+      skip: () => {
+        return [
+          {
+            component: 'Stories',
+            variant: 'Button With Text [white]',
+          },
+        ];
+      },
     }),
   ],
   stylesheets: [path.resolve(__dirname, 'test.css')],

--- a/src/register.js
+++ b/src/register.js
@@ -215,22 +215,22 @@ window.happo.nextExample = async () => {
     theme,
   } = examples[currentIndex];
 
-  let variant = rawVariant;
-  if (
-    window.happoSkipped &&
-    window.happoSkipped.some(
-      (item) => item.component === component && item.variant === variant,
-    )
-  ) {
-    console.log(
-      `Skipping ${component}, ${variant} since it is in the skip list`,
-    );
-    return { component, variant, skipped: true };
-  }
-
-  let pausedAtStep;
-
   try {
+    let variant = rawVariant;
+    if (
+      window.happoSkipped &&
+      window.happoSkipped.some(
+        (item) => item.component === component && item.variant === variant,
+      )
+    ) {
+      console.log(
+        `Skipping ${component}, ${variant} since it is in the skip list`,
+      );
+      return { component, variant, skipped: true };
+    }
+
+    let pausedAtStep;
+
     const docsRootElement = document.getElementById('docs-root');
     if (docsRootElement) {
       docsRootElement.setAttribute('data-happo-ignore', 'true');

--- a/src/register.js
+++ b/src/register.js
@@ -216,6 +216,18 @@ window.happo.nextExample = async () => {
   } = examples[currentIndex];
 
   let variant = rawVariant;
+  if (
+    window.happoSkipped &&
+    window.happoSkipped.some(
+      (item) => item.component === component && item.variant === variant,
+    )
+  ) {
+    console.log(
+      `Skipping ${component}, ${variant} since it is in the skip list`,
+    );
+    return { component, variant, skipped: true };
+  }
+
   let pausedAtStep;
 
   try {

--- a/src/register.js
+++ b/src/register.js
@@ -215,8 +215,10 @@ window.happo.nextExample = async () => {
     theme,
   } = examples[currentIndex];
 
+  let pausedAtStep;
+  let variant = rawVariant;
+
   try {
-    let variant = rawVariant;
     if (
       window.happoSkipped &&
       window.happoSkipped.some(
@@ -228,8 +230,6 @@ window.happo.nextExample = async () => {
       );
       return { component, variant, skipped: true };
     }
-
-    let pausedAtStep;
 
     const docsRootElement = document.getElementById('docs-root');
     if (docsRootElement) {


### PR DESCRIPTION
This will be similar to the feature we have for Cypress/Playwright, where you can tell Happo to skip certain examples. The idea here is that you can provide an array of `component`, `variant` items that will inform Happo to skip over certain stories and variants.

https://docs.happo.io/docs/cypress#skipping-snapshots