### PR TITLE
Update .gitignore and .npmignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,17 @@
-node_modules
 .happo-out
-/register.js
 /addon.js
-/preset.js
-/decorator.js
 /constants.js
-.yarn
+/decorator.js
+/preset.js
+/register.js
 dist
+node_modules
+
+# yarn https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,12 @@
-node_modules
+.eslintrc.js
+.github
 .happo-out
-test
+.happo.js
+.importjs.js
+.pnp.*
+.storybook
+.yarn
+.yarnrc.yml
 dist
+node_modules
+test


### PR DESCRIPTION
I noticed that there were some large files in the .yarn directory in the published package that we don't need to distribute in this package.

See here:

https://unpkg.com/browse/happo-plugin-storybook@4.3.0/

I also ended up with some .pnp.* files after getting yarn working in this project, and I think we want to .gitignore these as well.