### PR TITLE
Add HAPPO_API_SECRET to storybook6 build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
+      HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
       DISABLE_REACT_WEBPACK5_FRAMEWORK: true
       DISABLE_ADDONS: true
       HAPPO_DEBUG: true


### PR DESCRIPTION
I noticed that the storybook 6 build failed on a default branch build here:

https://github.com/happo/happo-plugin-storybook/actions/runs/9898839411/job/27346506331#step:11:23

In the logs, I see this:

> No `apiKey` or `apiSecret` found in config. Falling back to
> pull-request authentication.

It looks like the storybook 7 and 8 builds here don't have this issue, and I also see that those builds have the HAPPO_API_SECRET env var provided, so I am hoping that this will resolve this problem.

Separately, I think we can improve the error message in this validation a little bit.