### PR TITLE
Update actions/checkout and actions/setup-node from v2 to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,11 @@ jobs:
       YARN_IGNORE_PATH: 1
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 100
       - name: Use Node.js 18
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18
       - run: corepack enable
@@ -41,11 +41,11 @@ jobs:
       YARN_IGNORE_PATH: 1
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 100
       - name: Use Node.js 18
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18
       - run: corepack enable
@@ -65,11 +65,11 @@ jobs:
       YARN_IGNORE_PATH: 1
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 100
       - name: Use Node.js 18
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18
       - run: corepack enable


### PR DESCRIPTION
This removes some warnings related to the node version these actions are using.