### PR TITLE
Reproduce missing interactions bug

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -103,8 +103,8 @@ async function getExamples() {
       return result;
     }, [])
     .sort((a, b) => {
-      const aCompare = `${a.theme}-${a.storyId}`;
-      const bCompare = `${b.theme}-${b.storyId}`;
+      const aCompare = `${a.component}-${a.theme}-${a.storyId}`;
+      const bCompare = `${b.component}-${b.theme}-${b.storyId}`;
       if (aCompare === bCompare) {
         return 0;
       }


### PR DESCRIPTION
I've found an issue when the first story has interactions and you are using `forceHappoScreenshot`. The check for whether happo is running or not uses `if (currentIndex)` but the first step is 0. I have a fix in mind for this but I want to make sure that we have a way to reproduce first.