### PR TITLE
Don't skip interactive screenshots for first item

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -297,7 +297,7 @@ window.happo.nextExample = async () => {
 };
 
 export function forceHappoScreenshot(stepLabel) {
-  if (!currentIndex) {
+  if (!examples) {
     console.log(
       `Ignoring forceHappoScreenshot with step label "${stepLabel}" since we are not currently rendering for Happo`,
     );


### PR DESCRIPTION
When the first story in the list of stories in the whole storybook had a play function together with forceHappoScreenshot, we wouldn't include these screenshots in the report. This was because the check to see if we were currently running Happo was checking for `currentIndex`. This variable starts as `0`/falsy. To fix this, I'm instead checking to see if the normal init process has produced any examples. If not, we know we're not running Happo.

The bug that would materialize from this would be that the first story would only have one screenshot. The ones produced via forceHappoScreenshot inside the play function would be ignored. This problem would also be present multiple times if you were using `chunks` config in .happo.js. Every interactive story at the start of each chunk would also have missing screenshots.