### PR TITLE
Remove project.json after Storybook build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,9 @@ jobs:
       - run: yarn -v
       - run: yarn install --immutable
       - run: yarn lint
+      - run: yarn build
       - run: yarn test
-      - run: yarn build && npx -p happo.io happo-ci-github-actions
+      - run: npx -p happo.io happo-ci-github-actions
       - run: yarn build-local-storybook && HAPPO_USE_PREBUILT_PACKAGE=yes HAPPO_PROJECT=storybook8-prebuilt npx -p happo.io happo-ci-github-actions
 
   storybook7:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .happo-out
+.out
 /addon.js
 /constants.js
 /decorator.js

--- a/index.js
+++ b/index.js
@@ -108,6 +108,13 @@ function buildStorybook({ configDir, staticDir, outputDir }) {
 
     spawned.on('exit', (code) => {
       if (code === 0) {
+        try {
+          fs.unlinkSync(path.join(outputDir, 'project.json'));
+        } catch (error) {
+          console.warn(
+            `Ignoring error when attempting to remove project.json: ${error}`,
+          );
+        }
         resolve();
       } else {
         reject(new Error('Failed to build static storybook package'));

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = require('path');
+
+const happoStorybookPlugin = require('../index');
+
+jest.setTimeout(60000);
+
+it('removes the project.json after build', async () => {
+  const result = await happoStorybookPlugin().generateStaticPackage();
+  expect(fs.existsSync(path.join(result.path, 'project.json'))).toBeFalsy();
+});


### PR DESCRIPTION
This file is always different between builds. To help Happo make better use of caching, we can clean it out. We don't need this file on the happo side of things anyway.