### PR TITLE
Remove redundant console log

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -152,7 +152,6 @@ function renderStory(story, { force = false } = {}) {
   return new Promise((resolve) => {
     const timeout = time.originalSetTimeout(resolve, renderTimeoutMs);
     function handleRenderPhaseChanged(ev) {
-      console.log(ev);
       if (ev.newPhase === 'completed') {
         channel.off('storyRenderPhaseChanged', handleRenderPhaseChanged);
         clearTimeout(timeout);


### PR DESCRIPTION
I'm about to make logs available to users. This log that I added to debug something is quite spammy, and I want to make sure that logs are somewhat useful to our users.