### PR TITLE
Fix invoking function params

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,7 @@ jobs:
       - run: yarn set version 4.1.1
       - run: yarn install --immutable
       - run: rm .storybook/Interactive.stories.js
+      - run: mv .storybook/preview-storybook-6.js .storybook/preview.js
       - run: yarn add --dev storybook@6 @storybook/addon-actions@6 @storybook/addon-interactions@6 @storybook/api@6 @storybook/react@6 global @storybook/channels@6 @storybook/channel-websocket@6
       - run: yarn build
       - run: yarn storybook build --version

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,6 +1,11 @@
 const result = {
   stories: ['./**/*.stories.js'],
   staticDirs: ['../public'],
+  core: {
+    channelOptions: {
+      allowFunction: true,
+    },
+  },
 
   addons: process.env.DISABLE_ADDONS
     ? []

--- a/.storybook/preview-storybook-6.js
+++ b/.storybook/preview-storybook-6.js
@@ -1,5 +1,4 @@
 import { setThemeSwitcher, setRenderTimeoutMs } from '../register';
-import happoDecorator from '../src/decorator';
 
 setThemeSwitcher(async (theme, channel) => {
   // Make sure that it can be async
@@ -17,5 +16,3 @@ export default {
     },
   },
 };
-
-export const decorators = [happoDecorator];


### PR DESCRIPTION
When users were defining a happo param of type function, Storybook 8 wouldn't render it unless you set this in `.storybook/main.js`:

```js
  core: {
    channelOptions: {
      allowFunction: true,
    },
  },
```

By setting the allowFunction config option, the param shows up again. But if you clicked it, nothing would happen. From what I can understand, this is beacuse Storybook 8 will no longer automatically add decorators. It's our decorator that listens to the event, finds the function from the happo params and invokes it. From Storybook 8 we need to add the decorator explicitly in .storybook/preview.js

Fixes https://github.com/happo/happo-plugin-storybook/issues/137

This change will require a documentation update.