### PR TITLE
Show help text for function params in addon panel

### DIFF
--- a/src/addon.js
+++ b/src/addon.js
@@ -26,36 +26,51 @@ function HappoPanel() {
       }}
     >
       {happoParams ? (
-        <table>
-          <tbody>
-            {Object.keys(happoParams).map((key) => {
-              const val = happoParams[key];
-              return (
-                <tr key={key}>
-                  <td>
-                    <code>{key}:</code>
-                  </td>
-                  <td>
-                    {typeof val === 'function' ? (
-                      <button
-                        onClick={() =>
-                          emit('happo-event', {
-                            storyId: state.storyId,
-                            funcName: key,
-                          })
-                        }
-                      >
-                        Invoke
-                      </button>
-                    ) : (
-                      <code>{JSON.stringify(val)}</code>
-                    )}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+        <div>
+          <table>
+            <tbody>
+              {Object.keys(happoParams).map((key) => {
+                const val = happoParams[key];
+                return (
+                  <tr key={key}>
+                    <td>
+                      <code>{key}:</code>
+                    </td>
+                    <td>
+                      {typeof val === 'function' ? (
+                        <button
+                          onClick={() =>
+                            emit('happo-event', {
+                              storyId: state.storyId,
+                              funcName: key,
+                            })
+                          }
+                        >
+                          Invoke
+                        </button>
+                      ) : (
+                        <code>{JSON.stringify(val)}</code>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+          <p>
+            <small>
+              To see function params (e.g <b>waitFor</b>) in the panel, set{' '}
+              <a
+                href="https://storybook.js.org/docs/api/main-config/main-config-core#channeloptionsallowfunction"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <b>core.channelOptions.allowFunctions</b>
+              </a>{' '}
+              to <b>true</b>.
+            </small>
+          </p>
+        </div>
       ) : (
         <div>No happo params for this story</div>
       )}


### PR DESCRIPTION
If core.channelOptions.allowFunctions is false (the default), function params (like beforeScreenshot, waitFor) will not show up in the Happo panel. To help users discover this we can show a small help message in the panel.

I couldn't find an easy way to get the configuration value, so I'm displaying it all the time.