### PR TITLE
Allow Storybook stories to set Axe options

### DIFF
--- a/.storybook/Interactive.stories.js
+++ b/.storybook/Interactive.stories.js
@@ -20,6 +20,11 @@ export default {
   argTypes: {
     onClick: { action: true },
   },
+  parameters: {
+    happo: {
+      axeOptions: { rules: { 'color-contrast': { enabled: false } } },
+    },
+  },
 };
 
 export const Demo = {

--- a/.storybook/Story.stories.js
+++ b/.storybook/Story.stories.js
@@ -138,7 +138,10 @@ export const Themed = () => (
   <div style={{ color: 'gray' }}>My color is gray</div>
 );
 Themed.parameters = {
-  happo: { themes: ['black', 'white'] },
+  happo: {
+    themes: ['black', 'white'],
+    axeOptions: { rules: { 'color-contrast': { enabled: false } } },
+  },
 };
 
 export const NotPartOfHappo = () => <AsyncComponent />;

--- a/src/register.js
+++ b/src/register.js
@@ -88,6 +88,7 @@ async function getExamples() {
       let afterScreenshot;
       let targets;
       let themes;
+      let axeOptions;
       if (typeof parameters.happo === 'object' && parameters.happo !== null) {
         delay = parameters.happo.delay || defaultDelay;
         waitForContent = parameters.happo.waitForContent;
@@ -96,6 +97,7 @@ async function getExamples() {
         afterScreenshot = parameters.happo.afterScreenshot;
         targets = parameters.happo.targets;
         themes = parameters.happo.themes;
+        axeOptions = parameters.happo.axeOptions;
       }
       return {
         component: kind,
@@ -108,6 +110,7 @@ async function getExamples() {
         afterScreenshot,
         targets,
         themes,
+        axeOptions,
       };
     })
     .filter(Boolean)
@@ -236,7 +239,12 @@ window.happo.nextExample = async () => {
     waitFor,
     beforeScreenshot,
     theme,
+    axeOptions,
   } = examples[currentIndex];
+
+  // Set the axe configuration for the current story globally so that the
+  // Happo worker can pick it up
+  window.happoAxeOptions = axeOptions;
 
   let pausedAtStep;
   let variant = rawVariant;


### PR DESCRIPTION
This will allow Happo workers to pick up user configuration for the accessibilities snapshots. Using a global variable isn't ideal here but we need some way of communicating with the worker, and this was one of the interfaces that I saw would do the job.