### PR TITLE
Avoid fetching main branch when running on main branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 100
       - name: Fetch main branch
+        if: github.ref != 'refs/heads/main'
         run: git fetch origin main:main
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4


### PR DESCRIPTION
This git fetch fails like this when running on the default branch:

> fatal: refusing to fetch into branch 'refs/heads/main' checked out at
> '/home/runner/work/happo-plugin-storybook/happo-plugin-storybook'

I'm hoping to avoid this error by skipping this when we are already on the main branch.