### PR TITLE
Ignore #storybook-highlights-root element in screenshots

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -261,6 +261,13 @@ window.happo.nextExample = async () => {
     const rootElement = document.querySelector(SB_ROOT_ELEMENT_SELECTOR);
     rootElement.setAttribute('data-happo-ignore', 'true');
 
+    const highlightsRootElement = document.querySelector(
+      '#storybook-highlights-root',
+    );
+    if (highlightsRootElement) {
+      highlightsRootElement.setAttribute('data-happo-ignore', 'true');
+    }
+
     const { afterScreenshot } = examples[currentIndex - 1] || {};
     if (typeof afterScreenshot === 'function') {
       try {


### PR DESCRIPTION
This element is new in Storybook 9. It is causing all screenshots to be full width, because the element is part of the rect calculation in Happo.