### PR TITLE
Subclass Error for forceHappoScreenshot

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -16,6 +16,15 @@ let themeSwitcher;
 let forcedHappoScreenshotSteps;
 let shouldWaitForCompletedEvent = true;
 
+class ForcedHappoScreenshot extends Error {
+  constructor(stepLabel) {
+    super(`Forced screenshot with label "${stepLabel}"`);
+    this.name = 'ForcedHappoScreenshot';
+    this.type = 'ForcedHappoScreenshot';
+    this.step = stepLabel;
+  }
+}
+
 async function waitForSomeContent(elem, start = time.originalDateNow()) {
   const html = elem.innerHTML.trim();
   const duration = time.originalDateNow() - start;
@@ -359,11 +368,8 @@ export function forceHappoScreenshot(stepLabel) {
   forcedHappoScreenshotSteps = forcedHappoScreenshotSteps || [];
   forcedHappoScreenshotSteps.push({ stepLabel, done: false });
 
-  const e = new Error(`Forced screenshot with label "${stepLabel}"`);
-  e.type = 'ForcedHappoScreenshot';
-  e.step = stepLabel;
   console.log('Forcing happo screenshot', stepLabel);
-  throw e;
+  throw new ForcedHappoScreenshot(stepLabel);
 }
 
 export function setDefaultDelay(delay) {


### PR DESCRIPTION
Currently forceHappoScreenshot ends up logging a message that looks like this:

```
Error: Forced screenshot with label "foo"
  at ...
```

This is confusing, since it looks like some unhandled error. But in fact this is just how this feature works. I think we can make this clearer by properly subclassing the Error class. This should now look like this:

```
ForcedHappoScreenshot: Forced screenshot with label "foo"
  at ...
```