### PR TITLE
Bring back function params in addons panel

### DIFF
--- a/.storybook/Story.stories.js
+++ b/.storybook/Story.stories.js
@@ -190,7 +190,18 @@ AsyncWithWaitForContent.parameters = {
 };
 export const AsyncWithWaitFor = () => <AsyncContent />;
 AsyncWithWaitFor.parameters = {
-  happo: { waitFor: () => document.querySelector('.async-inner') },
+  happo: {
+    waitFor: () => {
+      return document.querySelector('.async-inner');
+    },
+    beforeScreenshot: () => {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve();
+        }, 100);
+      });
+    },
+  },
 };
 
 export const AsyncWithDelay = () => <AsyncContent />;
@@ -198,7 +209,7 @@ AsyncWithDelay.parameters = {
   happo: { delay: 1200 },
 };
 
-export const AsyncWithWaitForDataSelector = () => <AsyncContent />;
+export const AsyncWithWaitForDataSelector = () => <Async2 />;
 AsyncWithWaitForDataSelector.parameters = {
   happo: { waitFor: () => document.querySelector('[data-async-ready=true]') },
 };


### PR DESCRIPTION
With the Storybook 9 update, the ability to read params with a function as a value in the addons panel was removed. With that, the `core.channelOptions.allowFunction: true` was also removed.

In this commit I'm using a workaround to get the params back to the panel. I'm using the addons channel when mounting a story to communicate the list of params with functions. I then use that list to populate the list of params in the addon panel. The same invocation pattern as before -- sending a message across the addons channel.

To make invoking functions slightly better, I've added some logging of the return value. If the function returns a promise, we will also await the result and log them.