### PR TITLE
Use finished render phase to determine completed story

### DIFF
--- a/.storybook/Interactive.stories.js
+++ b/.storybook/Interactive.stories.js
@@ -39,12 +39,20 @@ export const Demo = {
       await forceHappoScreenshot('second click');
     });
   },
+
+  beforeEach: () => {
+    // Add afterEach hook for waiting and logging between tests
+    return async () => {
+      console.log('Test completed, waiting 500ms before next test...');
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    };
+  },
 };
 
 export const InteractiveThrowsError = {
   // This story exists to test what happens when the play function throws an
   // error that isn't caused by `forceHappoScreenshot`.
-  play: async ({ args, canvasElement, step }) => {
+  play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
     await new Promise((r) => setTimeout(r, 200));
 


### PR DESCRIPTION
I've been debugging a test suite with many play functions and forceHappoScreenshot calls. After they upgraded to Storybook 9 they startyed seeing cross-contamination, missing snapshots and flakiness. It turns out that most (all?) flake was coming from the fact that we used the `completed` and `errored` render phase events to determine that the story in its current state was done.

Stopping at the error or completed event meant that other events could end up in our lap later in the cycle. Things as `afterEach` and `aborted` for instance.

I spent a long time trying to clean up things when the next step in the play function is supposed to get rendered. In the end I found that switching to `finished` was much more stable.