### PR TITLE
Add check for undefined storyStore in getExamples

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -79,12 +79,18 @@ async function getStoryStore(startTime = time.originalDateNow()) {
 async function getExamples() {
   const storyStore = await getStoryStore();
 
+  if (!storyStore) {
+    throw new Error('Could not get Storybook story store');
+  }
+
   if (!storyStore.extract) {
     throw new Error('Missing Storybook Client API');
   }
+
   if (storyStore.cacheAllCSFFiles) {
     await storyStore.cacheAllCSFFiles();
   }
+
   return Object.values(storyStore.extract())
     .map(({ id, kind, story, parameters }) => {
       if (parameters.happo === false) {


### PR DESCRIPTION
I spotted this error in the wild:

```
TypeError: Cannot read properties of undefined (reading 'extract')
  at http://localhost:4444/assets/register-Dn7FoyLE.js:1:10272
  ...
```

I am wondering if it might be coming from this bit of code and I want to add a check here to make this error clearer.