### PR TITLE
Only install chromium for playwright

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - name: Install Playwright Browsers
-        run: yarn playwright install --with-deps
+        run: yarn playwright install chromium --with-deps
       - name: Start dev server and run tests
         run: |
           yarn dev & # Start dev server in background


### PR DESCRIPTION
We are only testing in one browser, and it is the default. We should be able to make this job more efficient by only installing that one browser.